### PR TITLE
Show payload in view modal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^8.2",
         "filament/filament": "^4.0",
+        "novadaemon/filament-pretty-json": "^3.1",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {

--- a/config/filament-failed-jobs.php
+++ b/config/filament-failed-jobs.php
@@ -1,5 +1,7 @@
 <?php
 
+use Filament\Support\Enums\Width;
+
 return [
     'resources' => [
         'enabled' => true,
@@ -10,4 +12,5 @@ return [
         'navigation_sort' => null,
         'navigation_count_badge' => false,
     ],
+    'modal-width' => Width::FiveExtraLarge,
 ];

--- a/src/Resources/FailedJobsResource.php
+++ b/src/Resources/FailedJobsResource.php
@@ -13,6 +13,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ViewField;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\Width;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
@@ -22,6 +23,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Str;
 use Livewire\Component;
+use Novadaemon\FilamentPrettyJson\Form\PrettyJsonField;
 use Vstruhar\FilamentFailedJobs\FilamentFailedJobsPlugin;
 use Vstruhar\FilamentFailedJobs\Models\FailedJob;
 use Vstruhar\FilamentFailedJobs\Resources\FailedJobsResource\Pages\ListFailedJobs;
@@ -51,6 +53,7 @@ class FailedJobsResource extends Resource
                     ->valueLabel('Model')
                     ->formatStateUsing(fn (Model $record) => $record->getModels()->mapWithKeys(fn ($value, $key) => ['$' . $key => $value])->toArray())
                     ->hidden(fn (Model $record) => $record->getModels()->isEmpty()),
+                PrettyJsonField::make('payload')->columnSpanFull(),
                 ViewField::make('exception')
                     ->view('filament-failed-jobs::exception-field')
                     ->columnSpan(2),
@@ -138,7 +141,8 @@ class FailedJobsResource extends Resource
                         $livewire->resetTable();
                     }),
                 ViewAction::make()
-                    ->button(),
+                    ->button()
+                    ->modalWidth(config('filament-failed-jobs.modal-width')),
             ])
             ->filters([
                 SelectFilter::make('queue')


### PR DESCRIPTION
I always miss the payload when viewing the failed job.
This adds a nice package from a fellow developer to display the payload in the view modal.

Also give users the option to config the modal width.
